### PR TITLE
Fix editor sizing bug

### DIFF
--- a/src/swnr.scss
+++ b/src/swnr.scss
@@ -57,11 +57,12 @@
         }
     }
     .editor {
-        min-height: 100px;
-        .editor-content {
-            height: 100%;
-        }
+        height: 150px;
     }
+    .editor-content {
+        height: 100%;
+    }
+    
     .core-stats {
         display: grid;
         grid-template-columns: repeat(3, 1fr);


### PR DESCRIPTION
The fix just needs to be something that doesn't set the min-height of the editor class, this seems to break the tinyMCE editor somehow. I've checked, and putting it inside of a div with a min-height is fine, so we may want to do that, but this also works, and sizes are totally fine for editing. I'm fine with either.