### PR TITLE
Add a simple foci tab on the character sheet

### DIFF
--- a/src/lang/en.yml
+++ b/src/lang/en.yml
@@ -340,6 +340,7 @@ swnr:
       weapons: Weapons
       inventory: Inventory
       armor: Armor
+      foci: Foci
       powers: Powers
     xp: XP
     delete-item: Delete Item

--- a/src/templates/actors/character-sheet.html
+++ b/src/templates/actors/character-sheet.html
@@ -141,6 +141,7 @@
         <a class="item" data-tab="armor">{{localize 'swnr.sheet.tabs.armor'}}</a>
         <a class="item" data-tab="inventory">{{localize 'swnr.sheet.tabs.inventory'}}</a>
         <a class="item" data-tab="skills">{{localize 'swnr.sheet.tabs.skills'}}</a>
+        <a class="item" data-tab="foci">{{localize 'swnr.sheet.tabs.foci'}}</a>
         <a class="item" data-tab="powers">{{localize 'swnr.sheet.tabs.powers'}}</a>
     </nav>
     <section class="sheet-body">
@@ -270,6 +271,22 @@
                 No skills? Click here to add some!
             </button>
             {{/if}}
+        </div>
+        <div class="tab foci" data-group="primary" data-tab="foci">
+                        <ul>
+                {{#each itemTypes.focus as |item id|}}
+                <li class="item focus" data-item-id="{{item._id}}">
+                    <h4 class="item-name">{{item.name}}</h4>
+                    <output>{{item.description}}</output>
+                    <div class="item-controls">
+                        <a class="item-control item-edit" title="{{localize  'swnr.sheet.edit-item'}}"><i
+                                class="fas fa-edit"></i></a>
+                        <a class="item-control item-delete" title="{{localize  'swnr.sheet.delete-item'}}"><i
+                                class="fas fa-trash"></i></a>
+                    </div>
+                </li>
+                {{/each}}
+            </ul>
         </div>
         <div class="tab powers" data-group="primary" data-tab="powers">
             <ul>

--- a/src/templates/items/focus-sheet.html
+++ b/src/templates/items/focus-sheet.html
@@ -4,5 +4,4 @@
     {{editor content=data.level1 target="data.level1" button=true owner=owner editable=editable }}
     <h3>{{localize 'swnr.foci.level2'}}</h3>
     {{editor content=data.level2 target="data.level2" button=true owner=owner editable=editable }}
-    <pre>{{stringify item}}</pre>
 </form>


### PR DESCRIPTION
I get that we probably want to do _more_ with foci in the future, but this at least adds them to the sheet and makes them playable.