### PR TITLE
Add NPC Saving Throws

### DIFF
--- a/src/lang/en.yml
+++ b/src/lang/en.yml
@@ -450,6 +450,7 @@ swnr:
       friendly: Friendly
     morale-check: Morale Check
     trained-skill: Trained Skill
+    generic-saving-throw: Saving Throw
     attacks-per-turn: Attacks Per Turn
     attack-bonus-hit: Attack Bonus Hit
     attack-bonus-damage: Attack Bonus Damage
@@ -463,6 +464,9 @@ swnr:
     skill:
       trained: "{actor} uses their trained skill."
       untrained: "{actor} uses their untrained skill."
+    generic-saves:
+      failure: Fails their Saving Throw!
+      success: Succeeds in their Saving Throw!
     unarmed: Unarmed
   migration:
     start: >-

--- a/src/module/actors/npc-sheet.ts
+++ b/src/module/actors/npc-sheet.ts
@@ -35,6 +35,7 @@ export class NPCActorSheet extends ActorSheet<SWNRNPCData, SWNRNPCActor> {
     html.find(".reaction").on("click", this._onReaction.bind(this));
     html.find(".morale").on("click", this._onMorale.bind(this));
     html.find(".skill").on("click", this._onSkill.bind(this));
+    html.find(".saves").on("click", this._onSaves.bind(this));
   }
 
   _onItemEdit(event: JQuery.ClickEvent): void {
@@ -184,6 +185,19 @@ export class NPCActorSheet extends ActorSheet<SWNRNPCData, SWNRNPCActor> {
         ? game.i18n.localize("swnr.npc.morale.failure")
         : game.i18n.localize("swnr.npc.morale.success");
     roll.toMessage({ flavor, speaker: { actor: this.actor._id } });
+  }
+
+  _onSaves(event: JQuery.ClickEvent): void {
+    event.preventDefault();
+    event.stopPropagation();
+
+    const roll = new Roll("1d20").roll();
+    console.log(roll);
+    const flavor =
+      roll.results[0] > this.actor.data.data.saves
+        ? games.i18n.localize("swnr.npc.generic-saves.failure")
+        : games.i18n.localize("swnr.npc.generic-saves.success");
+    roll.toMessage({ flavor, speaker: {actor: this.actor._id} });
   }
 
   _onSkill(event: JQuery.ClickEvent): void {

--- a/src/templates/actors/npc-sheet.html
+++ b/src/templates/actors/npc-sheet.html
@@ -175,7 +175,7 @@
       <div>
         <a class="saves">
           <i class="fa fa-dice-d20"></i>
-          {{localize 'swnr.npc.generic-saving-throw'}};
+          {{localize 'swnr.npc.generic-saving-throw'}} {{localize 'swnr.shhet.vs'}}
         </a>
         <input
           type="number"

--- a/src/templates/actors/npc-sheet.html
+++ b/src/templates/actors/npc-sheet.html
@@ -174,7 +174,7 @@
       </div>
       <div>
         <a class="saves">
-          <i class="fa fa-dice-d6"></i>
+          <i class="fa fa-dice-d20"></i>
           {{localize 'swnr.npc.generic-saving-throw'}};
         </a>
         <input

--- a/src/templates/actors/npc-sheet.html
+++ b/src/templates/actors/npc-sheet.html
@@ -172,6 +172,19 @@
           value="{{data.skillBonus}}"
         />
       </div>
+      <div>
+        <a class="saves">
+          <i class="fa fa-dice-d6"></i>
+          {{localize 'swnr.npc.generic-saving-throw'}};
+        </a>
+        <input
+          type="number"
+          name="data.saves"
+          min="0"
+          step="1"
+          value="{{data.saves}}"
+        />
+      </div>
     </div>
     <div class="effort">
       <h3>{{localize 'swnr.effort.title'}}</h3>

--- a/src/templates/actors/npc-sheet.html
+++ b/src/templates/actors/npc-sheet.html
@@ -175,7 +175,7 @@
       <div>
         <a class="saves">
           <i class="fa fa-dice-d20"></i>
-          {{localize 'swnr.npc.generic-saving-throw'}} {{localize 'swnr.shhet.vs'}}
+          {{localize 'swnr.npc.generic-saving-throw'}} {{localize 'swnr.sheet.vs'}}
         </a>
         <input
           type="number"


### PR DESCRIPTION
I've written this to add NPC generic saving throw support to the NPC sheets, based on pre-existing code. This should address issue #23.

This is my first contribution to a Foundry module, so could someone let me know how I can test this? 
