### PR TITLE
Fix enter opening Add Skills dialog

### DIFF
--- a/src/templates/actors/character-sheet.html
+++ b/src/templates/actors/character-sheet.html
@@ -513,7 +513,8 @@
             type=actor.data.type}} {{/each}}
           </div>
           {{else}}
-          <button class="skill-load-button" style="margin-top: 3em">
+          <button class="skill-load-button" style="margin-top: 3em"
+            type="button">
             No skills? Click here to add some!
           </button>
           {{/if}}


### PR DESCRIPTION
Without this, the browser treats the button as "submit" by default and activates it if <enter> is pressed when any input element is active. This happens even if the tab with the button isn't open.