### PR TITLE
Fix firefox warning caused by empty html string.

### DIFF
--- a/src/templates/dialogs/add-bulk-skills.html
+++ b/src/templates/dialogs/add-bulk-skills.html
@@ -1,11 +1,11 @@
 <form class="-m-2 p-2 bg-gray-200">
   <div>
     <input type="radio" name="skillList" value="revised" />
-    <label for="">Revised Skill List</label>
+    <label for="revised">Revised Skill List</label>
     <input type="radio" name="skillList" value="classic" />
-    <label for="">Classic Skill List</label>
+    <label for="classic">Classic Skill List</label>
     <input type="radio" name="skillList" value="none" />
-    <label for="">No Stock Skill List</label>
+    <label for="none">No Stock Skill List</label>
   </div>
   <div>
     <input type="radio" name="extra" value="none" />


### PR DESCRIPTION
Without this change, Firefox will print "Empty string passed to getElementById()." upon loading the page.