### PR TITLE
Add 'psychic' to skills as to not overload 'source'

### DIFF
--- a/src/lang/en.yml
+++ b/src/lang/en.yml
@@ -366,6 +366,7 @@ swnr:
     base-ac: Base AC
     vs: vs
     rollables: Rollables
+    psychic: Psychic
   settings:
     useHomebrewLuckSave: Use Homebrew Luck saves?
     useHomebrewLuckSaveHint: Uses 16 - Level for the save, no modifiers, just pure luck

--- a/src/migrations/skills.ts
+++ b/src/migrations/skills.ts
@@ -8,3 +8,11 @@ registerMigration(SWNRBaseItem, "0.4.0", 0, (item: Skill, pastUpdates) => {
     pastUpdates["data.source"] = "Psionic";
   return pastUpdates;
 });
+
+registerMigration(SWNRBaseItem, "0.4.2", 0, (item: Skill, pastUpdates) => {
+  if (item.type === "skill" && item.data.data.source === "Psionic") {
+    pastUpdates["data.source"] = "Revised";
+    pastUpdates["data.psychic"] = true;
+  }
+  return pastUpdates;
+});

--- a/src/module/actors/character.ts
+++ b/src/module/actors/character.ts
@@ -60,12 +60,7 @@ export class SWNRCharacterActor extends Actor<SWNRCharacterData> {
 
     // effort
     const psychicSkills = <Item<SWNRSkillData>[]>(
-      this.items.filter(
-        (i) =>
-          i.type === "skill" &&
-          (<Item<SWNRSkillData>>i).data.data.source.toLocaleLowerCase() ===
-            game.i18n.localize("swnr.skills.labels.psionic").toLocaleLowerCase()
-      )
+      this.items.filter((i) => (i.data.data as SWNRSkillData).psychic)
     );
     const effort = data.effort;
     effort.max =

--- a/src/module/types.d.ts
+++ b/src/module/types.d.ts
@@ -111,6 +111,7 @@ declare interface SWNRSkillData extends SWNRDecData {
   rank: -1 | 0 | 1 | 2 | 3 | 4;
   defaultStat: "ask" | SWNRStats;
   source: string;
+  psychic: boolean;
 }
 
 declare interface SWNRItemData extends SWNRBaseItemData {

--- a/src/module/utils.ts
+++ b/src/module/utils.ts
@@ -61,6 +61,7 @@ export function initSkills(
         description: game.i18n.localize(skillRoot + "text"),
         source: game.i18n.localize("swnr.skills.labels." + skillSet),
         dice: "2d6",
+        psychic: skillSet === "psionic",
       },
     };
   });

--- a/src/template.yml
+++ b/src/template.yml
@@ -188,3 +188,4 @@ Item:
     defaultStat: ask
     pool: 2D6
     source: ""
+    psychic: false

--- a/src/templates/items/skill-sheet.html
+++ b/src/templates/items/skill-sheet.html
@@ -53,5 +53,13 @@
         class="px-1 text-black border border-gray-800 bg-gray-400 bg-opacity-75 rounded-md"
       />
     </div>
+    <div>
+      <div>{{localize 'swnr.sheet.psychic'}}</div>
+      <input
+        type="checkbox"
+        name="data.psychic"
+        {{checked data.psychic}}
+      />
+    </div>
   </div>
 </form>


### PR DESCRIPTION
This commit is a starting point for generalizing skill Items. I think the 'source' field is a great idea but overloading it to also indicate that a skill is psychic limits its usefulness going forward. For instance a custom psychic skill with a source other than "Revised" could not be added without a loss of data. By adding another field for psychic skills we also no longer have to string compare against 'source' to calculate effort.

I noticed the migration that had been written to change from "psychic" to "Psionic." This commit labels the skills "Psychic." This is based on a search of the core book. It is definitely inconsistent though! There are 45 instances of "psychic skill" and 6 instances of "psionic skill." To be fair it is also true that "Psionic Skills" is used a sub-section heading. Let me know if you want me to change the naming to "Psionic" instead.