### PR TITLE
Hit Dice for NPCS with rolling health button and on createToken.  

### DIFF
--- a/src/lang/en.yml
+++ b/src/lang/en.yml
@@ -368,6 +368,8 @@ swnr:
     rollables: Rollables
     hit-dice: Hit Dice
   settings:
+    useRollNPCHD: Use NPC HD on token create?
+    useRollNPCHDHint: When creating a npc token, if the HP or Hit Dice (HD) has not been rolled, it will roll d8 HD for health automatically.
     useHomebrewLuckSave: Use Homebrew Luck saves?
     useHomebrewLuckSaveHint: Uses 16 - Level for the save, no modifiers, just pure luck
   chat:

--- a/src/lang/en.yml
+++ b/src/lang/en.yml
@@ -366,6 +366,7 @@ swnr:
     base-ac: Base AC
     vs: vs
     rollables: Rollables
+    hit-dice: Hit Dice
   settings:
     useHomebrewLuckSave: Use Homebrew Luck saves?
     useHomebrewLuckSaveHint: Uses 16 - Level for the save, no modifiers, just pure luck

--- a/src/module/actor-types.d.ts
+++ b/src/module/actor-types.d.ts
@@ -110,6 +110,7 @@ declare interface SWNRNPCData extends SWNRLivingTemplateBase {
     bonusDamage: number;
     number: number;
   };
+  hitDice: number;
   saves: number;
   speed: number;
   moralScore: number;

--- a/src/module/actors/npc-sheet.ts
+++ b/src/module/actors/npc-sheet.ts
@@ -63,6 +63,7 @@ export class NPCActorSheet extends ActorSheet<
     html.find(".morale").on("click", this._onMorale.bind(this));
     html.find(".skill").on("click", this._onSkill.bind(this));
     html.find(".saving-throw").on("click", this._onSavingThrow.bind(this));
+    html.find(".hit-dice-roll").on("click", this._onHitDice.bind(this));
   }
 
   _onItemEdit(event: JQuery.ClickEvent): void {
@@ -199,6 +200,21 @@ export class NPCActorSheet extends ActorSheet<
 
     // force re-render
     this.render();
+  }
+
+
+  // Set the max/value health based on D8 hit dice
+  _onHitDice(event: JQuery.ClickEvent): void {
+    event.preventDefault();
+    event.stopPropagation();
+    console.log(`Updating health using ${this.actor.data.data.hitDice} hit die `);
+    const roll = new Roll(`${this.actor.data.data.hitDice}d8`).roll();
+    if (roll != undefined && roll.total != undefined){
+      const newHealth = roll.total;
+      this.actor.update({"data.health.max": newHealth});
+      this.actor.update({"data.health.value": newHealth});
+    }
+    
   }
 
   _onMorale(event: JQuery.ClickEvent): void {

--- a/src/module/actors/npc-sheet.ts
+++ b/src/module/actors/npc-sheet.ts
@@ -207,14 +207,7 @@ export class NPCActorSheet extends ActorSheet<
   _onHitDice(event: JQuery.ClickEvent): void {
     event.preventDefault();
     event.stopPropagation();
-    console.log(`Updating health using ${this.actor.data.data.hitDice} hit die `);
-    const roll = new Roll(`${this.actor.data.data.hitDice}d8`).roll();
-    if (roll != undefined && roll.total != undefined){
-      const newHealth = roll.total;
-      this.actor.update({"data.health.max": newHealth});
-      this.actor.update({"data.health.value": newHealth});
-    }
-    
+    this.actor.rollHitDice();
   }
 
   _onMorale(event: JQuery.ClickEvent): void {
@@ -290,7 +283,8 @@ export class NPCActorSheet extends ActorSheet<
       }
     }
   }
-}
 
+
+}
 export const sheet = NPCActorSheet;
 export const types = ["npc"];

--- a/src/module/actors/npc-sheet.ts
+++ b/src/module/actors/npc-sheet.ts
@@ -202,7 +202,6 @@ export class NPCActorSheet extends ActorSheet<
     this.render();
   }
 
-
   // Set the max/value health based on D8 hit dice
   _onHitDice(event: JQuery.ClickEvent): void {
     event.preventDefault();
@@ -283,8 +282,6 @@ export class NPCActorSheet extends ActorSheet<
       }
     }
   }
-
-
 }
 export const sheet = NPCActorSheet;
 export const types = ["npc"];

--- a/src/module/actors/npc.ts
+++ b/src/module/actors/npc.ts
@@ -8,19 +8,17 @@ export class SWNRNPCActor extends SWNRBaseActor<"npc"> {
 
   // Set the max/value health based on D8 hit dice
   rollHitDice(): void {
-    console.log("rolling NPC hit dice");
-    if (this.data.data.hitDice != null) {
-      console.log(`Updating health using ${this.data.data.hitDice} hit die `);
+    if (this.data.data.hitDice != null && this.data.data.hitDice > 0) {
+      //For debug: console.log(`Updating health using ${this.data.data.hitDice} hit die `);
       const roll = new Roll(`${this.data.data.hitDice}d8`).roll();
       if (roll != undefined && roll.total != undefined){
         const newHealth = roll.total;
-        console.log("Health now = ", roll.result);
         this.update({"data.health.max": newHealth});
         this.update({"data.health.value": newHealth});
       }
     }
     else {
-      console.log("NPC has no hit dice, not rolling health");
+      //For debug: console.log("NPC has no hit dice, not rolling health");
     }
   }
 
@@ -47,13 +45,14 @@ export class SWNRNPCActor extends SWNRBaseActor<"npc"> {
     ]);
   }
 }
-// Unsure of right types for TS here.
+
 Hooks.on("createToken", (document, options, userId) => {
-  if (document.actor?.type == "npc") {
-    document.actor.rollHitDice();
+  if (game.settings.get("swnr","useRollNPCHD")) {
+    if (document.actor?.type == "npc") {
+      document.actor.rollHitDice();
+    }
   }
 });
-
 
 export const document = SWNRNPCActor;
 export const name = "npc";

--- a/src/module/actors/npc.ts
+++ b/src/module/actors/npc.ts
@@ -32,10 +32,6 @@ export class SWNRNPCActor extends SWNRBaseActor<"npc"> {
     super._onCreate(data, options, userId);
     if (this.data["items"]["length"] || game.userId !== userId) return;
 
-
-    this.data.data["hitDice"]=1;
-    // Can't figure out how to get this to work: this.actor.update({"data.hitDic": 1});
-
     this.createEmbeddedDocuments("Item", [
       {
         name: game.i18n.localize("swnr.npc.unarmed"),

--- a/src/module/actors/npc.ts
+++ b/src/module/actors/npc.ts
@@ -6,6 +6,24 @@ export class SWNRNPCActor extends SWNRBaseActor<"npc"> {
     e.value = e.max - e.current - e.scene - e.day;
   }
 
+  // Set the max/value health based on D8 hit dice
+  rollHitDice(): void {
+    console.log("rolling NPC hit dice");
+    if (this.data.data.hitDice != null) {
+      console.log(`Updating health using ${this.data.data.hitDice} hit die `);
+      const roll = new Roll(`${this.data.data.hitDice}d8`).roll();
+      if (roll != undefined && roll.total != undefined){
+        const newHealth = roll.total;
+        console.log("Health now = ", roll.result);
+        this.update({"data.health.max": newHealth});
+        this.update({"data.health.value": newHealth});
+      }
+    }
+    else {
+      console.log("NPC has no hit dice, not rolling health");
+    }
+  }
+
   _onCreate(
     data: Parameters<SWNRBaseActor["_onCreate"]>[0],
     options: Parameters<SWNRBaseActor["_onCreate"]>[1],
@@ -13,8 +31,8 @@ export class SWNRNPCActor extends SWNRBaseActor<"npc"> {
   ): void {
     super._onCreate(data, options, userId);
     if (this.data["items"]["length"] || game.userId !== userId) return;
-    console.log("creating npc");
-    console.log(this.data);
+
+
     this.data.data["hitDice"]=1;
     // Can't figure out how to get this to work: this.actor.update({"data.hitDic": 1});
 
@@ -33,6 +51,13 @@ export class SWNRNPCActor extends SWNRBaseActor<"npc"> {
     ]);
   }
 }
+// Unsure of right types for TS here.
+Hooks.on("createToken", (document, options, userId) => {
+  if (document.actor?.type == "npc") {
+    document.actor.rollHitDice();
+  }
+});
+
 
 export const document = SWNRNPCActor;
 export const name = "npc";

--- a/src/module/actors/npc.ts
+++ b/src/module/actors/npc.ts
@@ -13,6 +13,10 @@ export class SWNRNPCActor extends SWNRBaseActor<"npc"> {
   ): void {
     super._onCreate(data, options, userId);
     if (this.data["items"]["length"] || game.userId !== userId) return;
+    console.log("creating npc");
+    console.log(this.data);
+    this.data.data["hitDice"]=1;
+    // Can't figure out how to get this to work: this.actor.update({"data.hitDic": 1});
 
     this.createEmbeddedDocuments("Item", [
       {

--- a/src/module/settings.ts
+++ b/src/module/settings.ts
@@ -20,4 +20,13 @@ export const registerSettings = function (): void {
     type: Boolean,
     default: false,
   });
+
+  game.settings.register("swnr", "useRollNPCHD", {
+    name: "swnr.settings.useRollNPCHD",
+    hint: "swnr.settings.useRollNPCHDHint",
+    scope: "world",
+    config: true,
+    type: Boolean,
+    default: true,
+  });
 };

--- a/src/template.yml
+++ b/src/template.yml
@@ -79,6 +79,7 @@ Actor:
     attacks:
       bonusDamage: 0
       number: 1
+    hitDice: 0
     armorType: "street"
     speed: 10
     moralScore: 6

--- a/src/templates/actors/npc-sheet.html
+++ b/src/templates/actors/npc-sheet.html
@@ -95,6 +95,20 @@
         />
       </div>
       <div>
+        {{localize 'swnr.sheet.hit-dice'}}:
+        <input
+          class="w-8 border text-center px-1 border-gray-800 bg-gray-400 bg-opacity-75 placeholder-blue-800 placeholder-opacity-75 rounded-md"
+          type="number"
+          name="data.hitDice"
+          min="1"
+          step="1"
+          value="{{actor.data.data.hitDice}}"
+        />
+        <a class="hit-dice-roll">
+          <i class="fa fa-dice-d6"></i>
+        </a>
+      </div>        
+      <div>
         {{localize 'swnr.sheet.armor-class'}}:
         <input
           class="w-8 border text-center px-1 border-gray-800 bg-gray-400 bg-opacity-75 placeholder-blue-800 placeholder-opacity-75 rounded-md"


### PR DESCRIPTION
Added HD to the NPC template and spot on sheet for editing HitDice. A button on the sheet will roll health based on hit dice or will auto set when the npc (check if type is NPC in the hook) is created (dragged to scene). If no HD is set, this does not roll.

Small QoL edit on damage rolls to add a title/hover that gives the things used for rolling hits/damage.