### PR TITLE
Fix Vacc Suit AC

### DIFF
--- a/src/packs/field-equipment/Vacc suit.yml
+++ b/src/packs/field-equipment/Vacc suit.yml
@@ -1,6 +1,6 @@
 _id: wXAqbLF2a15jE84P
 data:
-  ac: 12
+  ac: 13
   bundle:
     amount: 1
     bundled: false


### PR DESCRIPTION
It had a incorrect AC amount. 

"No armor can be worn with a vacc suit, though the suit itself grants AC 13 to its wearers."